### PR TITLE
context: Don't default to forcing trusted only

### DIFF
--- a/libhif/hif-context.c
+++ b/libhif/hif-context.c
@@ -1209,8 +1209,6 @@ hif_context_setup (HifContext *context,
 		return FALSE;
 	priv->transaction = hif_transaction_new (context);
 	hif_transaction_set_sources (priv->transaction, priv->sources);
-	hif_transaction_set_flags (priv->transaction,
-				   HIF_TRANSACTION_FLAG_ONLY_TRUSTED);
 
 	/* setup a file monitor on the rpmdb */
 	rpmdb_path = g_build_filename (priv->install_root, "var/lib/rpm/Packages", NULL);


### PR DESCRIPTION
Repos have the "gpgcheck" flag which we do honor, so forcing trusted
only seems unnecessary.  I ran into this when trying to use hif-cmd
with gpgcheck=0 repos.  Rather than expose an --untrusted flag or
something, let's just honor the gpgcheck.

The main consumer in PackageKit already handles this flag itself
depending on client request.