### PR TITLE
context: Add API to override rpm macro

### DIFF
--- a/libhif/hif-context.h
+++ b/libhif/hif-context.h
@@ -115,6 +115,10 @@ void		 hif_context_set_only_trusted		(HifContext	*context,
 void		 hif_context_set_cache_age		(HifContext	*context,
 							 guint		 cache_age);
 
+void		 hif_context_set_rpm_macro		(HifContext	*context,
+							 const gchar	*key,
+							 const gchar    *value);
+
 /* object methods */
 gboolean	 hif_context_setup			(HifContext	*context,
 							 GCancellable	*cancellable,


### PR DESCRIPTION
This is needed by rpm-ostree, which exposes it to allow creating
stripped-down installs with _install_langs.