### PR TITLE
context: Don't set up file monitor on rpmdb if we're using an installroo...

### DIFF
--- a/libhif/hif-context.c
+++ b/libhif/hif-context.c
@@ -1253,17 +1253,19 @@ hif_context_setup (HifContext *context,
 	priv->transaction = hif_transaction_new (context);
 	hif_transaction_set_sources (priv->transaction, priv->sources);
 
-	/* setup a file monitor on the rpmdb */
-	rpmdb_path = g_build_filename (priv->install_root, "var/lib/rpm/Packages", NULL);
-	file_rpmdb = g_file_new_for_path (rpmdb_path);
-	priv->monitor_rpmdb = g_file_monitor_file (file_rpmdb,
-						   G_FILE_MONITOR_NONE,
-						   NULL,
-						   error);
-	if (priv->monitor_rpmdb == NULL)
-		return FALSE;
-	g_signal_connect (priv->monitor_rpmdb, "changed",
-			  G_CALLBACK (hif_context_rpmdb_changed_cb), context);
+	/* setup a file monitor on the rpmdb, if we're operating on the native / */
+	if (g_strcmp0 (priv->install_root, "/") != 0) {
+		rpmdb_path = g_build_filename (priv->install_root, "var/lib/rpm/Packages", NULL);
+		file_rpmdb = g_file_new_for_path (rpmdb_path);
+		priv->monitor_rpmdb = g_file_monitor_file (file_rpmdb,
+							   G_FILE_MONITOR_NONE,
+							   NULL,
+							   error);
+		if (priv->monitor_rpmdb == NULL)
+			return FALSE;
+		g_signal_connect (priv->monitor_rpmdb, "changed",
+				  G_CALLBACK (hif_context_rpmdb_changed_cb), context);
+	}
 
 	/* copy any vendor distributed cached metadata */
 	if (!hif_context_copy_vendor_cache (context, error))


### PR DESCRIPTION
...t

We can presume that if we're operating on a non-default root, we are
the only process altering that root.

I'm writing this patch because rpm-ostree actually moves /var/lib/rpm
to /usr/share/rpm after the compose is done, and this causes the GIO
inotify code to emit a warning for some reason.

Anyways, even if that bug was fixed, it's just pointless wakeups.