### PR TITLE
context: Add API to set global HTTP proxy

### DIFF
--- a/libhif/hif-context.c
+++ b/libhif/hif-context.c
@@ -67,6 +67,7 @@ struct _HifContextPrivate
 	gchar			*install_root;
 	gchar			*rpm_verbosity;
 	gchar			**native_arches;
+	gchar			*http_proxy;
 	gboolean		 cache_age;
 	gboolean		 check_disk_space;
 	gboolean		 check_transaction;
@@ -116,6 +117,7 @@ hif_context_finalize (GObject *object)
 	g_free (priv->install_root);
 	g_free (priv->os_info);
 	g_free (priv->arch_info);
+	g_free (priv->http_proxy);
 	g_strfreev (priv->native_arches);
 	g_object_unref (priv->lock);
 	g_object_unref (priv->state);
@@ -1092,6 +1094,41 @@ hif_context_set_rpm_macro (HifContext	*context,
 {
 	HifContextPrivate *priv = GET_PRIVATE (context);
 	g_hash_table_replace (priv->override_macros, g_strdup (key), g_strdup (value));
+}
+
+
+/**
+ * hif_context_get_http_proxy:
+ * @context: a #HifContext instance.
+ *
+ * Returns: the HTTP proxy; none is configured by default.
+ *
+ * Since: 0.1.9
+ **/
+const gchar *
+hif_context_get_http_proxy (HifContext *context)
+{
+	HifContextPrivate *priv = GET_PRIVATE (context);
+	return priv->http_proxy;
+}
+
+/**
+ * hif_context_set_http_proxy:
+ * @context: a #HifContext instance.
+ * @proxyurl: Proxy URL
+ *
+ * Set the HTTP proxy used by default.  Per-source configuration will
+ * override.
+ *
+ * Since: 0.1.9
+ **/
+void
+hif_context_set_http_proxy (HifContext	*context,
+			    const gchar    *proxyurl)
+{
+	HifContextPrivate *priv = GET_PRIVATE (context);
+	g_free (priv->http_proxy);
+	priv->http_proxy = g_strdup (proxyurl);
 }
 
 #define MAX_NATIVE_ARCHES	12

--- a/libhif/hif-context.h
+++ b/libhif/hif-context.h
@@ -84,6 +84,7 @@ gboolean	 hif_context_get_keep_cache		(HifContext	*context);
 gboolean	 hif_context_get_only_trusted		(HifContext	*context);
 guint		 hif_context_get_cache_age		(HifContext	*context);
 guint		 hif_context_get_installonly_limit	(HifContext	*context);
+const gchar	*hif_context_get_http_proxy		(HifContext	*context);
 
 /* setters */
 void		 hif_context_set_repo_dir		(HifContext	*context,
@@ -118,6 +119,8 @@ void		 hif_context_set_cache_age		(HifContext	*context,
 void		 hif_context_set_rpm_macro		(HifContext	*context,
 							 const gchar	*key,
 							 const gchar    *value);
+void             hif_context_set_http_proxy		(HifContext	*context,
+							 const gchar    *proxyurl);
 
 /* object methods */
 gboolean	 hif_context_setup			(HifContext	*context,

--- a/libhif/hif-source.c
+++ b/libhif/hif-source.c
@@ -780,6 +780,8 @@ hif_source_set_keyfile_data (HifSource *source, GError **error)
 
 	/* proxy is optional */
 	proxy = g_key_file_get_string (priv->keyfile, priv->id, "proxy", NULL);
+	if (proxy == NULL)
+		proxy = g_strdup (hif_context_get_http_proxy (priv->context));
 	if (!lr_handle_setopt (priv->repo_handle, error, LRO_PROXY, proxy))
 		return FALSE;
 


### PR DESCRIPTION
I want rpm-ostree to honor the "http_proxy" environment variable like
ostree (and many other tools) do.