### PR TITLE
source: Remove hif_source_is_supported()

### DIFF
--- a/libhif/hif-source.c
+++ b/libhif/hif-source.c
@@ -442,39 +442,6 @@ hif_source_is_source (HifSource *source)
 }
 
 /**
- * hif_source_is_supported:
- * @source: a #HifSource instance.
- *
- * Returns: %TRUE if the source is supported
- *
- * Since: 0.1.0
- **/
-gboolean
-hif_source_is_supported (HifSource *source)
-{
-	HifSourcePrivate *priv = GET_PRIVATE (source);
-	guint i;
-	const gchar *valid[] = { "fedora",
-				 "fedora-debuginfo",
-				 "fedora-source",
-				 "rawhide",
-				 "rawhide-debuginfo",
-				 "rawhide-source",
-				 "updates",
-				 "updates-debuginfo",
-				 "updates-source",
-				 "updates-testing",
-				 "updates-testing-debuginfo",
-				 "updates-testing-source",
-				 NULL };
-	for (i = 0; valid[i] != NULL; i++) {
-		if (g_strcmp0 (priv->id, valid[i]) == 0)
-			return TRUE;
-	}
-	return FALSE;
-}
-
-/**
  * hif_source_set_id:
  * @source: a #HifSource instance.
  * @id: the ID, e.g. "fedora-updates"

--- a/libhif/hif-source.h
+++ b/libhif/hif-source.h
@@ -137,7 +137,6 @@ HyRepo		 hif_source_get_repo		(HifSource		*source);
 gboolean	 hif_source_is_devel		(HifSource		*source);
 gboolean	 hif_source_is_local		(HifSource		*source);
 gboolean	 hif_source_is_source		(HifSource		*source);
-gboolean	 hif_source_is_supported	(HifSource		*source);
 
 /* setters */
 void		 hif_source_set_id		(HifSource		*source,


### PR DESCRIPTION
IMO, this is too hardcoded, not even respecting the fact that just the
Red Hat family has CentOS and Red Hat Enterprise Linux.  Also, were
the concept to make sense, third parties should be able to provide
support for their own repos.

Since it's PackageKit that has the concept of "supported", let's move
this there.

See https://github.com/hughsie/PackageKit/pull/30/commits