### PR TITLE
Support the "exclude" element in repo files

### DIFF
--- a/libhif/hif-source.h
+++ b/libhif/hif-source.h
@@ -126,6 +126,7 @@ const gchar	*hif_source_get_packages	(HifSource		*source);
 HifSourceEnabled hif_source_get_enabled		(HifSource		*source);
 guint		 hif_source_get_cost		(HifSource		*source);
 HifSourceKind	 hif_source_get_kind		(HifSource		*source);
+gchar          **hif_source_get_exclude_packages(HifSource		*source);
 gboolean	 hif_source_get_gpgcheck	(HifSource		*source);
 gboolean	 hif_source_get_gpgcheck_md	(HifSource		*source);
 gchar		*hif_source_get_description	(HifSource		*source);


### PR DESCRIPTION
For a downstream consumer of rpm-ostree in Red Hat Enterprise Linux
Atomic Host, we use the "exclude" in yum repo files.  There are a few
cases, but the biggest is "systemd-container" which conflicts with
systemd.  The workaround is to exclude systemd-container where it's
not wanted.