### PR TITLE
Add API to disable hifdb (yumdb)

### DIFF
--- a/libhif/hif-cmd.c
+++ b/libhif/hif-cmd.c
@@ -435,6 +435,7 @@ main (int argc, char *argv[])
 	gboolean ret;
 	gboolean verbose = FALSE;
 	gboolean version = FALSE;
+	gboolean opt_disable_yumdb = FALSE;
 	guint retval = 1;
 	_cleanup_free_ gchar *opt_root = NULL;
 	_cleanup_free_ gchar *opt_reposdir = NULL;
@@ -449,6 +450,8 @@ main (int argc, char *argv[])
 			"Directory for caches", NULL },
 		{ "verbose", 'v', 0, G_OPTION_ARG_NONE, &verbose,
 			"Show extra debugging information", NULL },
+		{ "disable-yumdb", 'v', 0, G_OPTION_ARG_NONE, &opt_disable_yumdb,
+			"Disable writing updates to the yumdb", NULL },
 		{ "version", '\0', 0, G_OPTION_ARG_NONE, &version,
 			"Show version", NULL },
 		{ NULL}
@@ -537,6 +540,7 @@ main (int argc, char *argv[])
 	hif_context_set_check_transaction (priv->context, TRUE);
 	hif_context_set_keep_cache (priv->context, FALSE);
 	hif_context_set_cache_age (priv->context, 24 * 60 * 60);
+	hif_context_set_yumdb_enabled (priv->context, !opt_disable_yumdb);
 
 	/* set verbose? */
 	if (verbose) {

--- a/libhif/hif-context.c
+++ b/libhif/hif-context.c
@@ -64,6 +64,7 @@ struct _HifContextPrivate
 	gboolean		 check_disk_space;
 	gboolean		 check_transaction;
 	gboolean		 only_trusted;
+	gboolean		 enable_yumdb;
 	gboolean		 keep_cache;
 	HifLock			*lock;
 	HifTransaction		*transaction;
@@ -142,6 +143,7 @@ hif_context_init (HifContext *context)
 	priv->install_root = g_strdup ("/");
 	priv->check_disk_space = TRUE;
 	priv->check_transaction = TRUE;
+	priv->enable_yumdb = TRUE;
 	priv->state = hif_state_new ();
 	priv->lock = hif_lock_new ();
 	priv->cache_age = 60 * 60 * 24 * 7; /* 1 week */
@@ -549,6 +551,21 @@ hif_context_get_only_trusted (HifContext *context)
 }
 
 /**
+ * hif_context_get_yumdb_enabled:
+ * @context: a #HifContext instance.
+ *
+ * Returns: %TRUE if yum database is enabled
+ *
+ * Since: 0.1.9
+ **/
+gboolean
+hif_context_get_yumdb_enabled (HifContext *context)
+{
+	HifContextPrivate *priv = GET_PRIVATE (context);
+	return priv->enable_yumdb;
+}
+
+/**
  * hif_context_get_cache_age:
  * @context: a #HifContext instance.
  *
@@ -813,6 +830,24 @@ hif_context_set_only_trusted (HifContext *context, gboolean only_trusted)
 {
 	HifContextPrivate *priv = GET_PRIVATE (context);
 	priv->only_trusted = only_trusted;
+}
+
+
+/**
+ * hif_context_set_yumdb_enabled:
+ * @context: a #HifContext instance.
+ * @enable_yumdb: %FALSE to disable yum database (default is %TRUE)
+ *
+ * Enables or disables writing the yum database.
+ *
+ * Since: 0.1.9
+ **/
+void
+hif_context_set_yumdb_enabled (HifContext	*context,
+			       gboolean	 enable_yumdb)
+{
+	HifContextPrivate *priv = GET_PRIVATE (context);
+	priv->enable_yumdb = enable_yumdb;
 }
 
 /**

--- a/libhif/hif-context.h
+++ b/libhif/hif-context.h
@@ -85,6 +85,7 @@ gboolean	 hif_context_get_check_disk_space	(HifContext	*context);
 gboolean	 hif_context_get_check_transaction	(HifContext	*context);
 gboolean	 hif_context_get_keep_cache		(HifContext	*context);
 gboolean	 hif_context_get_only_trusted		(HifContext	*context);
+gboolean	 hif_context_get_yumdb_enabled		(HifContext	*context);
 guint		 hif_context_get_cache_age		(HifContext	*context);
 guint		 hif_context_get_installonly_limit	(HifContext	*context);
 const gchar	*hif_context_get_http_proxy		(HifContext	*context);
@@ -124,6 +125,8 @@ void		 hif_context_set_keep_cache		(HifContext	*context,
 							 gboolean	 keep_cache);
 void		 hif_context_set_only_trusted		(HifContext	*context,
 							 gboolean	 only_trusted);
+void		 hif_context_set_yumdb_enabled		(HifContext	*context,
+							 gboolean	 enable_yumdb);
 void		 hif_context_set_cache_age		(HifContext	*context,
 							 guint		 cache_age);
 

--- a/libhif/hif-db.h
+++ b/libhif/hif-db.h
@@ -65,6 +65,9 @@ struct _HifDbClass
 GType		 hif_db_get_type		(void);
 HifDb		*hif_db_new			(HifContext	*context);
 
+void		 hif_db_set_enabled		(HifDb          *db,
+						 gboolean        enabled);
+
 /* getters */
 gchar		*hif_db_get_string		(HifDb		*db,
 						 HyPackage	 package,

--- a/libhif/hif-transaction.c
+++ b/libhif/hif-transaction.c
@@ -1456,5 +1456,7 @@ hif_transaction_new (HifContext *context)
 	priv->context = context;
 	g_object_add_weak_pointer (G_OBJECT (priv->context), (void **) &priv->context);
 	priv->db = hif_db_new (context);
+	/* Propagate db enablement */
+	hif_db_set_enabled (priv->db, hif_context_get_yumdb_enabled (context));
 	return HIF_TRANSACTION (transaction);
 }


### PR DESCRIPTION
For rpm-ostree, the packages are composed on a server side.  A lot of
the yumdb entries aren't meaningful in this context.  There's a
further issue that yumdb's one-file-per-value model badly conflicts
with an OSTree design choice of one-http-request-per-changed-file.

So currently we don't ship it at all, and rather than have libhif
write it out only for us to rm -rf it, let's support not writing it at
all.