### PR TITLE
transaction: Add flag to disable documentation

### DIFF
--- a/libhif/hif-transaction.c
+++ b/libhif/hif-transaction.c
@@ -1246,6 +1246,7 @@ hif_transaction_commit (HifTransaction *transaction,
 	HyPackage pkg;
 	HyPackage pkg_tmp;
 	rpmprobFilterFlags problems_filter = 0;
+	rpmtransFlags rpmts_flags = RPMTRANS_FLAG_NONE;
 	HifTransactionPrivate *priv = GET_PRIVATE (transaction);
 
 	/* take lock */
@@ -1432,10 +1433,13 @@ hif_transaction_commit (HifTransaction *transaction,
 	if (priv->flags & HIF_TRANSACTION_FLAG_ALLOW_DOWNGRADE)
 		problems_filter |= RPMPROB_FILTER_OLDPACKAGE;
 
+	if (priv->flags & HIF_TRANSACTION_FLAG_NODOCS)
+		rpmts_flags |= RPMTRANS_FLAG_NODOCS;
+
 	/* run the transaction */
 	priv->state = hif_state_get_child (state);
 	priv->step = HIF_TRANSACTION_STEP_STARTED;
-	rpmtsSetFlags (priv->ts, RPMTRANS_FLAG_NONE);
+	rpmtsSetFlags (priv->ts, rpmts_flags);
 	g_debug ("Running actual transaction");
 	hif_state_set_allow_cancel (state, FALSE);
 	rc = rpmtsRun (priv->ts, NULL, problems_filter);

--- a/libhif/hif-transaction.h
+++ b/libhif/hif-transaction.h
@@ -72,6 +72,7 @@ struct _HifTransactionClass
  * @HIF_TRANSACTION_FLAG_ONLY_TRUSTED:		Only install trusted packages
  * @HIF_TRANSACTION_FLAG_ALLOW_REINSTALL:	Allow package reinstallation
  * @HIF_TRANSACTION_FLAG_ALLOW_DOWNGRADE:	Allow package downrades
+ * @HIF_TRANSACTION_FLAG_NODOCS:	        Don't install documentation
  *
  * The transaction flags.
  **/
@@ -80,6 +81,7 @@ typedef enum {
 	HIF_TRANSACTION_FLAG_ONLY_TRUSTED		= 1 << 0,
 	HIF_TRANSACTION_FLAG_ALLOW_REINSTALL	= 1 << 1,
 	HIF_TRANSACTION_FLAG_ALLOW_DOWNGRADE	= 1 << 2,
+	HIF_TRANSACTION_FLAG_NODOCS		= 1 << 3
 } HifTransactionFlag;
 
 GType		 hif_transaction_get_type		(void);


### PR DESCRIPTION
See https://github.com/projectatomic/rpm-ostree/pull/99 for where
we're exposing a "documentation": false flag.  This allows exposing
the same yum/rpm transaction option in libhif.