### PR TITLE
Revert "Remove the unused hif_context_get_goal()"

### DIFF
--- a/libhif/hif-context.c
+++ b/libhif/hif-context.c
@@ -450,6 +450,21 @@ hif_context_get_sack (HifContext	*context)
 }
 
 /**
+ * hif_context_get_goal: (skip)
+ * @context: a #HifContext instance.
+ *
+ * Returns: (transfer none): the HyGoal object
+ *
+ * Since: 0.1.0
+ **/
+HyGoal
+hif_context_get_goal (HifContext	*context)
+{
+	HifContextPrivate *priv = GET_PRIVATE (context);
+	return priv->goal;
+}
+
+/**
  * hif_context_get_state:
  * @context: a #HifContext instance.
  *

--- a/libhif/hif-context.h
+++ b/libhif/hif-context.h
@@ -93,6 +93,7 @@ GPtrArray	*hif_context_get_sources		(HifContext	*context);
 HifRepos	*hif_context_get_repos			(HifContext	*context);
 HifTransaction	*hif_context_get_transaction		(HifContext	*context);
 HySack   	 hif_context_get_sack			(HifContext	*context);
+HyGoal  	 hif_context_get_goal			(HifContext	*context);
 #endif
 HifState* 	 hif_context_get_state			(HifContext	*context);
 


### PR DESCRIPTION
This reverts commit 55e2f3e45c016a303a89ba2792d390e838331212.

It is used by rpm-ostree, and I believe in a safe way as we're not
sharing it between threads.