### PR TITLE
context: Reinstate default of not using ONLY_TRUSTED

### DIFF
--- a/libhif/hif-context.c
+++ b/libhif/hif-context.c
@@ -400,8 +400,6 @@ hif_context_ensure_transaction (HifContext *context)
 		priv->transaction = hif_transaction_new (context);
 		priv->transaction_thread = g_thread_self ();
 		hif_transaction_set_sources (priv->transaction, priv->sources);
-		hif_transaction_set_flags (priv->transaction,
-					   HIF_TRANSACTION_FLAG_ONLY_TRUSTED);
 		return;
 	}
 


### PR DESCRIPTION
Regression from c17515c0a5e33b81ee15fdfbdce38930f91a6631

Commit 5fbf26f900f2430b345636d29692b7bac20f91f6 changed things so that
we didn't use HIF_TRANSACTION_FLAG_ONLY_TRUSTED by default (clients
could set it).

The thread safety commit above apparently accidentally re-introduced
it.