### PR TITLE
transaction: Add HIF_TRANSACTION_FLAG_OSTREE_MODE

### DIFF
--- a/libhif/hif-rpmts.h
+++ b/libhif/hif-rpmts.h
@@ -30,10 +30,15 @@
 #include <rpm/rpmts.h>
 #include <hawkey/package.h>
 
+typedef enum {
+	HIF_RPMTS_FLAG_ALLOW_UNTRUSTED = (1 << 0),
+	HIF_RPMTS_FLAG_IS_UPDATE = (1 << 1),
+	HIF_RPMTS_FLAG_OSTREE_MODE = (1 << 2)
+} HifRpmTsFlags;
+
 gboolean	 hif_rpmts_add_install_filename	(rpmts		 ts,
 						 const gchar	*filename,
-						 gboolean	 allow_untrusted,
-						 gboolean	 is_update,
+						 HifRpmTsFlags   flags,
 						 GError		**error);
 gboolean	 hif_rpmts_add_remove_pkg	(rpmts		 ts,
 						 HyPackage	 pkg,

--- a/libhif/hif-transaction.h
+++ b/libhif/hif-transaction.h
@@ -73,6 +73,7 @@ struct _HifTransactionClass
  * @HIF_TRANSACTION_FLAG_ALLOW_REINSTALL:	Allow package reinstallation
  * @HIF_TRANSACTION_FLAG_ALLOW_DOWNGRADE:	Allow package downrades
  * @HIF_TRANSACTION_FLAG_NODOCS:	        Don't install documentation
+ * @HIF_TRANSACTION_FLAG_OSTREE_MODE:	        Assume installation on top of an OSTree root
  *
  * The transaction flags.
  **/
@@ -81,7 +82,8 @@ typedef enum {
 	HIF_TRANSACTION_FLAG_ONLY_TRUSTED		= 1 << 0,
 	HIF_TRANSACTION_FLAG_ALLOW_REINSTALL	= 1 << 1,
 	HIF_TRANSACTION_FLAG_ALLOW_DOWNGRADE	= 1 << 2,
-	HIF_TRANSACTION_FLAG_NODOCS		= 1 << 3
+	HIF_TRANSACTION_FLAG_NODOCS		= 1 << 3,
+	HIF_TRANSACTION_FLAG_OSTREE_MODE	= 1 << 4
 } HifTransactionFlag;
 
 GType		 hif_transaction_get_type		(void);


### PR DESCRIPTION
The goal of this patch is to help support rpm-ostree package layering.
The way this works is that we unpack layered packages on top of a new
*hardlinked* tree.  However, if any packages had scriptlets that
mutate a file in place (as opposed to make-new-then-rename), that
would corrupt the object store and potentially break rollback.

It turns out that *most* scripts in Fedora are safe, but ultimately
the way I think this should work is that only scripts in e.g.
/usr/share/rpm/scriptlets
which are known verified safe can be run.

Anyways, if set, HIF_TRANSACTION_FLAG_OSTREE_MODE does basically two things:
 - Verifies before installing a package (while we have it open for GPG checks)
   that a package has no scripts
 - Disables all scripts in the RPM transaction

We can't just do the latter as that would allow installing packages
that didn't work (e.g. shared libraries without running ldconfig).