### PR TITLE
transaction: Remove obsoleted packages when committing the transaction

### DIFF
--- a/libhif/hif-transaction.c
+++ b/libhif/hif-transaction.c
@@ -1272,6 +1272,7 @@ hif_transaction_commit (HifTransaction *transaction,
 
 	/* add things to remove */
 	priv->remove = hif_goal_get_packages (goal,
+					      HIF_PACKAGE_INFO_OBSOLETE,
 					      HIF_PACKAGE_INFO_REMOVE,
 					      -1);
 	for (i = 0; i < priv->remove->len; i++) {


### PR DESCRIPTION
This matches the behaviour with DNF / yum that automatically remove any
obsoleted packages.

https://bugzilla.redhat.com/show_bug.cgi?id=1211991