### PR TITLE
context: Fix rpmdb file monitor with / installs

### DIFF
--- a/libhif/hif-context.c
+++ b/libhif/hif-context.c
@@ -1354,7 +1354,7 @@ hif_context_setup (HifContext *context,
 		return FALSE;
 
 	/* setup a file monitor on the rpmdb, if we're operating on the native / */
-	if (g_strcmp0 (priv->install_root, "/") != 0) {
+	if (g_strcmp0 (priv->install_root, "/") == 0) {
 		rpmdb_path = g_build_filename (priv->install_root, "var/lib/rpm/Packages", NULL);
 		file_rpmdb = g_file_new_for_path (rpmdb_path);
 		priv->monitor_rpmdb = g_file_monitor_file (file_rpmdb,


### PR DESCRIPTION
Commit c50214d43a20941b2a950dd04d822fdc33a137d0 added a guard that was
supposed to avoid firing the rpmdb monitor signals when using a
non-default install root, but got the guard condition backwards which
prevented it working with regular / installs.

Fixing this makes PackageKit properly invalidate its internal caches
when an external program, such as dnf, touches the rpmdb.