### PR TITLE
source: Don't prepend package name to download error messages

### DIFF
--- a/libhif/hif-source.c
+++ b/libhif/hif-source.c
@@ -1658,13 +1658,8 @@ hif_source_download_package (HifSource *source,
 			/* ignore */
 			g_clear_error (&error_local);
 		} else {
-			g_set_error (error,
-				     HIF_ERROR,
-				     HIF_ERROR_INTERNAL_ERROR,
-				     "cannot download %s to %s: %s",
-				     hy_package_get_location (pkg),
-				     directory_slash,
-				     error_local->message);
+			g_propagate_error (error, error_local);
+			error_local = NULL;
 			goto out;
 		}
 	}


### PR DESCRIPTION
libhif error messages tend to be long, *and* often missing
critical context.  Specifically right now I'm hitting an error
where repodata doesn't match a package.

librepo says:

```
Cannot download toplink/packages/kubernetes/0.15.0/0.4.git0ea87e4.el7/x86_64/kubernetes-0.15.0-0.4.git0ea87e4.el7.x86_64.rpm: All mirrors were tried
```

And in this case we aren't even using a mirrorlist!  It's just a
`baseurl=` repo.

Anyways libhif prepends this with the URL again, which is unnecessary.
I can't think of a case where the local path is going to be very
useful; it should be obvious where things will be cached for the user.