### PR TITLE
source: Add hif_source_set_required()

### DIFF
--- a/libhif/hif-sack.c
+++ b/libhif/hif-sack.c
@@ -110,7 +110,8 @@ hif_sack_add_source (HySack sack,
 					 state_local,
 					 &error_local);
 		if (!ret) {
-			if (g_error_matches (error_local,
+			if (!hif_source_get_required (src) &&
+			    g_error_matches (error_local,
 					     HIF_ERROR,
 					     HIF_ERROR_CANNOT_FETCH_SOURCE)) {
 				g_warning ("Skipping refresh of %s: %s",

--- a/libhif/hif-source.c
+++ b/libhif/hif-source.c
@@ -54,6 +54,7 @@ typedef struct _HifSourcePrivate	HifSourcePrivate;
 struct _HifSourcePrivate
 {
 	HifSourceEnabled enabled;
+	gboolean	 required;
 	gboolean	 gpgcheck_md;
 	gboolean	 gpgcheck_pkgs;
 	gchar		*gpgkey;
@@ -133,6 +134,9 @@ hif_source_init (HifSource *source)
 	priv->repo_result = lr_result_init ();
 	priv->filenames_md = g_hash_table_new_full (g_str_hash, g_str_equal,
 						    g_free, g_free);
+	priv->required = FALSE;  /* This is the original default which we're
+				  * keeping for compatibility.
+				  */
 }
 
 /**
@@ -281,6 +285,21 @@ hif_source_get_enabled (HifSource *source)
 {
 	HifSourcePrivate *priv = GET_PRIVATE (source);
 	return priv->enabled;
+}
+
+/**
+ * hif_source_get_required:
+ * @source: a #HifSource instance.
+ *
+ * Returns: %TRUE if failure fetching this source is fatal
+ *
+ * Since: 0.2.1
+ **/
+gboolean
+hif_source_get_required (HifSource *source)
+{
+	HifSourcePrivate *priv = GET_PRIVATE (source);
+	return priv->required;
 }
 
 /**
@@ -576,6 +595,24 @@ hif_source_set_enabled (HifSource *source, HifSourceEnabled enabled)
 	/* packages implies metadata */
 	if (priv->enabled & HIF_SOURCE_ENABLED_PACKAGES)
 		priv->enabled |= HIF_SOURCE_ENABLED_METADATA;
+}
+
+/**
+ * hif_source_set_required:
+ * @source: a #HifSource instance.
+ * @required: if the source is required
+ *
+ * Sets whether failure to retrieve the source is fatal; by default it
+ * is not.
+ *
+ * Since: 0.2.1
+ **/
+void
+hif_source_set_required (HifSource *source, gboolean required)
+{
+	HifSourcePrivate *priv = GET_PRIVATE (source);
+
+	priv->required = required;
 }
 
 /**

--- a/libhif/hif-source.h
+++ b/libhif/hif-source.h
@@ -123,6 +123,7 @@ const gchar	*hif_source_get_location	(HifSource		*source);
 const gchar	*hif_source_get_filename	(HifSource		*source);
 const gchar	*hif_source_get_packages	(HifSource		*source);
 HifSourceEnabled hif_source_get_enabled		(HifSource		*source);
+gboolean         hif_source_get_required	(HifSource		*source);
 guint		 hif_source_get_cost		(HifSource		*source);
 HifSourceKind	 hif_source_get_kind		(HifSource		*source);
 gchar          **hif_source_get_exclude_packages(HifSource		*source);
@@ -153,6 +154,8 @@ void		 hif_source_set_packages_tmp	(HifSource		*source,
 						 const gchar		*packages_tmp);
 void		 hif_source_set_enabled		(HifSource		*source,
 						 HifSourceEnabled	 enabled);
+void		 hif_source_set_required	(HifSource		*source,
+						 gboolean       	 required);
 void		 hif_source_set_cost		(HifSource		*source,
 						 guint			 cost);
 void		 hif_source_set_kind		(HifSource		*source,


### PR DESCRIPTION
Currently with rpm-ostree, if a source metadata fails to download
due to 404, network error or whatever, we `g_warning()` and skip it.

Usually we then later out with an error due to missing packages, but
that might not always happen, if e.g. the repo had override packages.

If I specify a source, I want a failure to download it to be a hard
error.  I considered changing the default, but that would likely
break PackageKit (right?).

So add an API to opt-in to hard errors on source unavailablity.