### PR TITLE
Add a configure option to choose between dnf's yumdb and yum's yumdb

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -99,6 +99,13 @@ AC_TRY_COMPILE([#include <stdlib.h>
 AC_DEFINE_UNQUOTED(BUILDOPT_HAWKEY_SACK_CREATE2, $BUILDOPT_HAWKEY_SACK_CREATE2, [Hawkey ABI change])
 AC_PATH_PROG([XSLTPROC], [xsltproc])
 
+# whether to use /var/lib/dnf/yumdb or /var/lib/yum/yumdb
+AC_ARG_ENABLE(dnf-yumdb, AS_HELP_STRING([--enable-dnf-yumdb],[use dnf/yumdb instead of yum/yumdb @<:@default=yes@:>@]),
+              enable_dnf_yumdb=$enableval,enable_dnf_yumdb=yes)
+if test x$enable_dnf_yumdb = xyes; then
+  AC_DEFINE_UNQUOTED(BUILDOPT_USE_DNF_YUMDB,1,[Use dnf/yumdb instead of yum/yumdb])
+fi
+
 AC_CONFIG_FILES([
 Makefile
 libhif/Makefile

--- a/libhif/hif-db.c
+++ b/libhif/hif-db.c
@@ -102,6 +102,11 @@ hif_db_get_dir_for_package (HifDb *db, HyPackage package)
 	const gchar *pkgid;
 	HifDbPrivate *priv = GET_PRIVATE (db);
 	const gchar *instroot;
+#ifdef BUILDOPT_USE_DNF_YUMDB
+	static const gchar *yumdb_dir = "/var/lib/dnf/yumdb";
+#else
+	static const gchar *yumdb_dir = "/var/lib/yum/yumdb";
+#endif
 
 	pkgid = hif_package_get_pkgid (package);
 	if (pkgid == NULL)
@@ -111,8 +116,9 @@ hif_db_get_dir_for_package (HifDb *db, HyPackage package)
 	if (g_strcmp0 (instroot, "/") == 0)
 		instroot = "";
 
-	return g_strdup_printf ("%s/var/lib/yum/yumdb/%c/%s-%s-%s-%s-%s",
+	return g_strdup_printf ("%s%s/%c/%s-%s-%s-%s-%s",
 				instroot,
+				yumdb_dir,
 				hy_package_get_name (package)[0],
 				pkgid,
 				hy_package_get_name (package),


### PR DESCRIPTION
In F22, DNF is the default and has switched to using /var/lib/dnf/yumdb
instead of /var/lib/yum/yumdb.

This commit adds a configure option to choose which yumdb to use. In
Fedora 22 and later where DNF is the default, we'll set it in downstream
packaging to use dnf's yumdb, and in use --disable-dnf-yumdb in older
Fedora releases to keep on using yum's yumdb.