### PR TITLE
Tear down HifContext weak pointers when the objects are finalized

### DIFF
--- a/libhif/hif-db.c
+++ b/libhif/hif-db.c
@@ -58,6 +58,22 @@ G_DEFINE_TYPE (HifDb, hif_db, G_TYPE_OBJECT)
 #define GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), HIF_TYPE_DB, HifDbPrivate))
 
 /**
+ * hif_db_finalize:
+ **/
+static void
+hif_db_finalize (GObject *object)
+{
+	HifDb *db = HIF_DB (object);
+	HifDbPrivate *priv = GET_PRIVATE (db);
+
+	if (priv->context != NULL)
+		g_object_remove_weak_pointer (G_OBJECT (priv->context),
+		                              (void **) &priv->context);
+
+	G_OBJECT_CLASS (hif_db_parent_class)->finalize (object);
+}
+
+/**
  * hif_db_init:
  **/
 static void
@@ -71,6 +87,8 @@ hif_db_init (HifDb *db)
 static void
 hif_db_class_init (HifDbClass *klass)
 {
+	GObjectClass *object_class = G_OBJECT_CLASS (klass);
+	object_class->finalize = hif_db_finalize;
 	g_type_class_add_private (klass, sizeof (HifDbPrivate));
 }
 

--- a/libhif/hif-source.c
+++ b/libhif/hif-source.c
@@ -118,6 +118,9 @@ hif_source_finalize (GObject *object)
 		hy_repo_free (priv->repo);
 	if (priv->keyfile != NULL)
 		g_key_file_unref (priv->keyfile);
+	if (priv->context != NULL)
+		g_object_remove_weak_pointer (G_OBJECT (priv->context),
+		                              (void **) &priv->context);
 
 	G_OBJECT_CLASS (hif_source_parent_class)->finalize (object);
 }

--- a/libhif/hif-transaction.c
+++ b/libhif/hif-transaction.c
@@ -101,6 +101,9 @@ hif_transaction_finalize (GObject *object)
 		g_ptr_array_unref (priv->remove);
 	if (priv->remove_helper != NULL)
 		g_ptr_array_unref (priv->remove_helper);
+	if (priv->context != NULL)
+		g_object_remove_weak_pointer (G_OBJECT (priv->context),
+		                              (void **) &priv->context);
 
 	G_OBJECT_CLASS (hif_transaction_parent_class)->finalize (object);
 }


### PR DESCRIPTION
When commit cd2acd8 switched to using weak pointers for HifContext, it
forgot to do the weak pointer teardown in finalize.

I only noticed it when reading the code; unclear if this actually led to
any issues.